### PR TITLE
Allow more prefixes on CDC interface names

### DIFF
--- a/adafruit_board_toolkit/circuitpython_serial.py
+++ b/adafruit_board_toolkit/circuitpython_serial.py
@@ -24,6 +24,9 @@ import sys
 import serial.tools.list_ports
 from serial.tools.list_ports_common import ListPortInfo
 
+# Some CircuitPython boards do not have interface names that start with "CircuitPython".
+INTERFACE_PREFIXES = ("CircuitPython", "Sol", "StringCarM0Ex")
+
 
 def comports() -> Sequence[ListPortInfo]:
     """Return all the comports recognized as being associated with a CircuitPython board."""
@@ -51,14 +54,22 @@ def comports() -> Sequence[ListPortInfo]:
     return tuple(
         port
         for port in ports
-        if port.interface and port.interface.startswith("CircuitPython CDC")
+        if port.interface
+        and port.interface.startswith(
+            tuple((prefix + " CDC" for prefix in INTERFACE_PREFIXES))
+        )
     )
 
 
 def repl_comports() -> Sequence[ListPortInfo]:
     """Return all comports presenting a CircuitPython REPL."""
+    # The trailing space in " CDC " is deliberate.
     return tuple(
-        port for port in comports() if port.interface.startswith("CircuitPython CDC ")
+        port
+        for port in comports()
+        if port.interface.startswith(
+            tuple(prefix + " CDC " for prefix in INTERFACE_PREFIXES)
+        )
     )
 
 
@@ -66,6 +77,11 @@ def data_comports() -> Sequence[ListPortInfo]:
     """Return all comports presenting a CircuitPython serial connection
     used for data transfer, not the REPL.
     """
+    # The trailing space in " CDC2 " is deliberate.
     return tuple(
-        port for port in comports() if port.interface.startswith("CircuitPython CDC2 ")
+        port
+        for port in comports()
+        if port.interface.startswith(
+            tuple(prefix + " CDC2 " for prefix in INTERFACE_PREFIXES)
+        )
     )


### PR DESCRIPTION
A couple of CircuitPython boards are currently not recognized by `circuitpython_serial` because their interface names start with something other than "CircuitPython". This fix handles those boards.

See more discussion in the "unbranding effort issue: https://github.com/adafruit/circuitpython/issues/2854#issuecomment-824101345. We can also match against some other interface name pattern, but we need to figure out what it should be. That could be in this PR or later. This library is used by Mu, so Mu needs a version bump PR for this library each time it changes.

Tagging @stargirl @CedarGroveStudios @hugodahl for interest and review if you feel so inclined.

Tested on an existing CircuitPython board. To test on some other board:
```sh
$ git clone https://github.com/dhalbert/Adafruit_Board_Toolkit
$ git checkout sol-stringcar
$ pip3 install Adafruit_Board_Toolkit
# Use a venv or similar if you don't want to clean up afterwards.
```
Plug in your board.
```py
>>> import adafruit_board_toolkit.circuitpython_serial
>>> ports = adafruit_board_toolkit.circuitpython_serial.repl_comports()   # should show something non-empty
>>> ports[0].interface    # should show your interface name
```

