### PR TITLE
fix for reading the interface name on Apple Silicon

### DIFF
--- a/adafruit_board_toolkit/_list_ports_osx.py
+++ b/adafruit_board_toolkit/_list_ports_osx.py
@@ -235,46 +235,22 @@ class SuitableSerialInterface(object):
     pass
 
 
-def scan_interfaces():
-    """
-    helper function to scan USB interfaces
-    returns a list of SuitableSerialInterface objects with name and id attributes
-    """
-    interfaces = []
-    for service in GetIOServicesByType('IOSerialBSDClient'):
-        device = get_string_property(service, "IOCalloutDevice")
-        if device:
-            usb_device = GetParentDeviceByType(service, "IOUSBInterface")
-            if usb_device:
-                name = get_string_property(usb_device, "USB Interface Name") or None
-                locationID = get_int_property(usb_device, "locationID", kCFNumberSInt32Type) or ''
-                i = SuitableSerialInterface()
-                i.id = locationID
-                i.name = name
-                interfaces.append(i)
-    return interfaces
-
-
-def search_for_locationID_in_interfaces(serial_interfaces, locationID):
-    for interface in serial_interfaces:
-        if (interface.id == locationID):
-            return interface.name
-    return None
-
-
 def comports(include_links=False):
     # XXX include_links is currently ignored. are links in /dev even supported here?
     # Scan for all iokit serial ports
     services = GetIOServicesByType('IOSerialBSDClient')
     ports = []
-    serial_interfaces = scan_interfaces()
     for service in services:
         # First, add the callout device file.
         device = get_string_property(service, "IOCalloutDevice")
+        #device = get_string_property(service, "IODialinDevice")
         if device:
             info = list_ports_common.ListPortInfo(device)
             # find the serial interface associated with this device
-            serial_interface = GetParentDeviceByType(service, "IOUSBInterface")
+            # like below, IOUSBInterface is IOUSBHostInterface on Apple Silicon
+            serial_interface = GetParentDeviceByType(service, "IOUSBHostInterface")
+            if serial_interface is None:
+                serial_interface = GetParentDeviceByType(service, "IOUSBInterface")
             # If the serial port is implemented by IOUSBDevice
             # NOTE IOUSBDevice was deprecated as of 10.11 and finally on Apple Silicon
             # devices has been completely removed.  Thanks to @oskay for this patch.
@@ -293,10 +269,10 @@ def comports(include_links=False):
                 info.manufacturer = get_string_property(usb_device, kUSBVendorString)
                 locationID = get_int_property(usb_device, "locationID", kCFNumberSInt32Type)
                 info.location = location_to_string(locationID)
-                info.interface = get_string_property(serial_interface, "USB Interface Name")
-                # fallback to the serial_interfaces search if necessary
+                info.interface = get_string_property(serial_interface, "kUSBString")
+                # "kUSBString" might not be available on older macOS ? who knows ?
                 if info.interface is None:
-                    info.interface = search_for_locationID_in_interfaces(serial_interfaces, locationID)
+                    info.interface = get_string_property(serial_interface, "USB Interface Name")
                 info.apply_usb_info()
             ports.append(info)
     return ports


### PR DESCRIPTION
On M1 the interface object is now reported by `IOObjectGetClass()` as a `IOUSBHostInterface`.
And the `USB Interface Name` property is gone. But there is a `kUSBString` property with the same content.

Also some cleanup to remove `search_for_locationID_in_interfaces` since I'm more confident it is rendered useless now (and would need to be fixed for M1 anyway). If I could know why it was done that way to begin with. Maybe there are or were cases on older macOS where the interface and serial objects are not in the same hierarchy.