### PR TITLE
Set PySerial minimum version to 3.5 in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
     install_requires=[
-        "pyserial",
+        "pyserial~=3.5",
     ],
     # Choose your license
     license="MIT",


### PR DESCRIPTION
The `skip_link_detection` argument from the  `serial.tools.list_ports_common.ListPortInfo()` constructor is only present in PySerial >= 3.5.

https://github.com/adafruit/Adafruit_Board_Toolkit/blob/64362180c7d2338e2c679f76ef425f649176e5ef/adafruit_board_toolkit/_list_ports_windows.py#L342

https://github.com/pyserial/pyserial/commit/2f57d7dff85e0b680a91e7edf241d03bf0a789ed


This minimum version is already configured in `requirements.txt` but it wasn't in the `install_requires` from setup.py.