### PR TITLE
Fixed links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Introduction
     :alt: Discord
 
 
-.. image:: https://github.com/adafruit/Adafruit_CircuitPython_Board_Toolkit/workflows/Build%20CI/badge.svg
-    :target: https://github.com/adafruit/Adafruit_CircuitPython_Board_Toolkit/actions
+.. image:: https://github.com/adafruit/Adafruit_Board_Toolkit/workflows/Build%20CI/badge.svg
+    :target: https://github.com/adafruit/Adafruit_Board_Toolkit/actions
     :alt: Build Status
 
 
@@ -54,5 +54,5 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/adafruit/Adafruit_CircuitPython_Board_Toolkit/blob/main/CODE_OF_CONDUCT.md>`_
+<https://github.com/adafruit/Adafruit_Board_Toolkit/blob/main/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.

--- a/adafruit_board_toolkit/circuitpython_serial.py
+++ b/adafruit_board_toolkit/circuitpython_serial.py
@@ -14,7 +14,7 @@ CircuitPython board identification and information
 # imports
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Board_Toolkit.git"
+__repo__ = "https://github.com/adafruit/Adafruit_Board_Toolkit.git"
 
 from typing import Sequence
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,7 +127,7 @@ html_static_path = ["_static"]
 html_favicon = "_static/favicon.ico"
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "Adafruit_CircuitPython_Board_toolkitLibrarydoc"
+htmlhelp_basename = "Adafruit_Board_toolkitLibrarydoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Table of Contents
 .. toctree::
     :caption: Other Links
 
-    Download <https://github.com/adafruit/Adafruit_CircuitPython_Board_Toolkit/releases/latest>
+    Download <https://github.com/adafruit/Adafruit_Board_Toolkit/releases/latest>
     CircuitPython Reference Documentation <https://circuitpython.readthedocs.io>
     CircuitPython Support Forum <https://forums.adafruit.com/viewforum.php?f=60>
     Discord Chat <https://adafru.it/discord>


### PR DESCRIPTION
Just confirming this library should be called Adafruit_Board_Toolkit and not Adafruit_CircuitPython_Board_Toolkit, right?