### PR TITLE
Build and push wheels to PyPI during release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,5 +67,5 @@ jobs:
       run: |
         pip install --upgrade setuptools wheel twine readme_renderer testresources
         python setup.py sdist
-        python setup.py bdist_wheel --universal
+        python setup.py bdist_wheel
         twine check dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,15 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v1
+    - name: Set up Python
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: '3.x'
     - name: Versions
       run: |
-        python3 --version
+        python --version
+        python -m pip --version
+        python -m pip list
     - name: Checkout Current Repo
       uses: actions/checkout@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,5 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
         python setup.py sdist
+        python setup.py bdist_wheel
         twine upload dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         echo ::set-output name=setup-py::$( find . -wholename './setup.py' )
     - name: Set up Python
       if: contains(steps.need-pypi.outputs.setup-py, 'setup.py')
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ bundles
 dist
 **/*.egg-info
 .vscode
+.venv/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 
 repos:
 -   repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 22.12.0
     hooks:
     - id: black
       exclude: _list_ports_.*.py
@@ -19,7 +19,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/pycqa/pylint
-    rev: pylint-2.7.1
+    rev: v2.15.8
     hooks:
     -   id: pylint
         name: pylint (library code)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ release = "1.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Fixes issue https://github.com/adafruit/Adafruit_Board_Toolkit/issues/9

Basically builds a wheel in the GitHub Actions workflow that runs on release and pushes the dist folder to PyPI.

I gave this a quick spin and locally pushed to test-PyPI by manually executing the steps in the yaml file, and it looks like it works fine:

<img width="1464" alt="image" src="https://user-images.githubusercontent.com/4189262/207132527-de79d8c0-48b5-4f00-bf51-0434378c24e8.png">

(I also deleted the project, so that it doesn't clash if anybody else tries to upload the distributions to the test PyPI server).