### PR TITLE
Example: Make it clear it is the REPL not found

### DIFF
--- a/examples/board_toolkit_simpletest.py
+++ b/examples/board_toolkit_simpletest.py
@@ -6,7 +6,7 @@ import adafruit_board_toolkit.circuitpython_serial
 
 comports = adafruit_board_toolkit.circuitpython_serial.repl_comports()
 if not comports:
-    raise Exception("No CircuitPython boards found")
+    raise Exception("No CircuitPython REPL COM port found")
 
 # Print the device paths or names that connect to a REPL.
 print([comport.device for comport in comports])


### PR DESCRIPTION
There could be a CircuitPython board connected, just that the REPL is not exposed. Previous message could be misleading.